### PR TITLE
tenshi.openrc-init: move the pid file into /run.

### DIFF
--- a/tenshi.openrc-init
+++ b/tenshi.openrc-init
@@ -1,14 +1,13 @@
 #!/sbin/openrc-run
 
-# These are custom variables.
+# This is a custom variable.
 TENSHI_CFG="/etc/tenshi/tenshi.conf"
-TENSHI_PIDDIR="/run/tenshi"
 
 # And these all belong to OpenRC.
 command="/usr/sbin/tenshi"
 extra_commands="checkconfig"
 extra_started_commands="reload flush"
-pidfile="${TENSHI_PIDDIR}/tenshi.pid"
+pidfile="/run/tenshi.pid"
 command_args="-c ${TENSHI_CFG} -P ${pidfile}"
 description="tenshi log monitoring daemon"
 


### PR DESCRIPTION
After 46b0148, it becomes possible to create the PID file directly in
/run/tenshi.pid. This is a little simpler, and doesn't require us to
ensure that /run is created before we use it (unlike /run/tenshi), so
let's do it.