### PR TITLE
Reset $! before check.

### DIFF
--- a/tenshi
+++ b/tenshi
@@ -1007,6 +1007,7 @@ sub csv_out {
 sub prepare_process {
     $0 = 'tenshi';
     chdir '/'                   or clean_up and die RED "[ERROR] can't chdir to /: $!\n";
+    undef $!;
     if($> == 0) { # only works when root
         $) = "$gid $gid"; (!$!) or clean_up and die RED "[ERROR] can't reset supplementary groups: $!\n";
     }


### PR DESCRIPTION
In general $! is only set by unsuccessful system calls.  If it is
used to check whether a system call has been successful, it has to
be cleared.  Otherwise any failed system call in the past may affect
the outcome.